### PR TITLE
Added tag parameter

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -4,7 +4,7 @@ Use the PyPI plugin to deploy a Python package to a PyPI server.
 * `username` - The username to login with (optional)
 * `password` - A password to login with (optional)
 * `distributions` - A list of distribution types to deploy (optional)
-* `tag` - Aa egg_info build tag (optional)
+* `tag` - An egg_info build tag (optional)
 
 The following is an example configuration for your .drone.yml:
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -4,6 +4,7 @@ Use the PyPI plugin to deploy a Python package to a PyPI server.
 * `username` - The username to login with (optional)
 * `password` - A password to login with (optional)
 * `distributions` - A list of distribution types to deploy (optional)
+* `tag` - Aa egg_info build tag (optional)
 
 The following is an example configuration for your .drone.yml:
 
@@ -13,6 +14,7 @@ publish:
     repository: https://pypi.python.org/pypi
     username: guido
     password: secret
+    tag: $$DRONE_BUILD_NUMBER
     distributions:
       - sdist
       - bdist_wheel

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ type Params struct {
 	Password      *string  `json:"password,omitempty"`
 	Repository    *string  `json:"repository,omitempty"`
 	Username      *string  `json:"username,omitempty"`
+	Tag      	  *string  `json:"tag,omitempty"`
 }
 
 func main() {
@@ -112,6 +113,9 @@ func (v *Params) Upload() *exec.Cmd {
 		distributions = v.Distributions
 	}
 	args := []string{"setup.py"}
+	if v.Tag != nil {
+		args = append(args, "egg_info", "-b", v.Tag)
+	}
 	for i := range distributions {
 		args = append(args, distributions[i])
 	}

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ type Params struct {
 	Password      *string  `json:"password,omitempty"`
 	Repository    *string  `json:"repository,omitempty"`
 	Username      *string  `json:"username,omitempty"`
-	Tag      	  *string  `json:"tag,omitempty"`
+	Tag           *string  `json:"tag,omitempty"`
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -147,7 +147,6 @@ func TestUpload(t *testing.T) {
 	}
 }
 
-
 // TestUploadTagged checks if a distutils upload command can be properly
 // formatted with egg_info tag.
 func TestUploadTagged(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -147,6 +147,23 @@ func TestUpload(t *testing.T) {
 	}
 }
 
+
+// TestUploadTagged checks if a distutils upload command can be properly
+// formatted with egg_info tag.
+func TestUploadTagged(t *testing.T) {
+	v := Params{Tag: "1234"}
+	c := v.Upload()
+	exp := []string{"python", "setup.py", "egg_info", "-b", "1234", "sdist", "upload", "-r", "pypi"}
+	if len(c.Args) != len(exp) {
+		t.Errorf("Expected %d, got %d", len(exp), len(c.Args))
+	}
+	for i := range c.Args {
+		if c.Args[i] != exp[i] {
+			t.Errorf("Expected %s, got %s", strings.Join(exp, " "), strings.Join(c.Args, " "))
+		}
+	}
+}
+
 func sPtr(s string) *string {
 	return &s
 }


### PR DESCRIPTION
This PR add an optional tag parameter allowing to add an egg_info tag.

Use case: given a package with the following version: `x.y.z.dev` and a tag parameter `1234`, it will produce a `x.y.z.dev1234` on publication. Very useful for continuous build.
Allow to write in `.drone.yml`:

``` yaml
publish:
  pypi:
    repository: https://pypi.python.org/pypi
    username: guido
    password: secret
    tag: $$DRONE_BUILD_NUMBER
    distributions:
      - sdist
      - bdist_wheel
```

I haven't been able to run the tests because of the missing `github.com/drone/drone-go/plugin` dependency and I'm not used to go language, so if you notice something wrong, I'll fix it ASAP.
