### PR TITLE
Use parent directory of setup.py path

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -23,7 +23,15 @@ func (p Plugin) buildCommand() *exec.Cmd {
 	// Set the default of distributions in here
 	// as CLI package still has issues with string slice defaults
 	distributions := []string{"sdist"}
-	if len(p.Distributions) > 0 {
+	// Sanitize bad dist values
+	inputDists := make([]string, 0, len(p.Distributions))
+	for _, dist := range p.Distributions {
+		if strings.TrimSpace(dist) == "" {
+			continue
+		}
+		inputDists = append(inputDists, dist)
+	}
+	if len(inputDists) > 0 {
 		distributions = p.Distributions
 	}
 	args := []string{p.SetupFile}

--- a/testdata/setup.py
+++ b/testdata/setup.py
@@ -6,7 +6,7 @@ setup(
     version='0.1.0',
     description='Testing drone-pypi publishes, no other purpose.',
     url='https://github.com/xoxys/drone-pypi',
-    packages=['testdata/drone_pypi_test'],
+    packages=['drone_pypi_test'],
     maintainer='Robert Kaussow',
     maintainer_email="xoxys@rknet.org",
 )


### PR DESCRIPTION
If a package is nested in a sub directory, then this plugin doens't
work. So change the working directory based on the `setupfile` path
(with the code to restore the original directory afterwards, just in
case).