### PR TITLE
include option for nested dist

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,12 @@ func main() {
 			Usage:  "skip build and only upload pre-build packages",
 			EnvVar: "PLUGIN_SKIP_BUILD",
 		},
+		cli.StringFlag{
+			Name:	"dist_dir",
+			Usage:  "used when distribution directory is not in build root",
+			Value:  "dist/",
+			EnvVar: "PLUGIN_DIST_DIR",
+		},
 	}
 
 	app.Run(os.Args)
@@ -65,6 +71,7 @@ func run(c *cli.Context) {
 		SetupFile:     c.String("setupfile"),
 		Distributions: c.StringSlice("distributions"),
 		SkipBuild:     c.Bool("skip_build"),
+		DistDir:       c.String("dist_dir"),
 	}
 
 	if err := plugin.Exec(); err != nil {

--- a/plugin.go
+++ b/plugin.go
@@ -16,6 +16,7 @@ type Plugin struct {
 	SetupFile     string
 	Distributions []string
 	SkipBuild     bool
+	DistDir       string
 }
 
 func (p Plugin) buildCommand() *exec.Cmd {
@@ -41,7 +42,7 @@ func (p Plugin) uploadCommand() *exec.Cmd {
 	args = append(args, p.Username)
 	args = append(args, "--password")
 	args = append(args, p.Password)
-	args = append(args, filepath.Join(filepath.Dir(p.SetupFile), "dist/*"))
+	args = append(args, filepath.Join(filepath.Dir(p.DistDir), "/*"))
 
 	return exec.Command("twine", args...)
 }

--- a/plugin.go
+++ b/plugin.go
@@ -42,7 +42,7 @@ func (p Plugin) uploadCommand() *exec.Cmd {
 	args = append(args, p.Username)
 	args = append(args, "--password")
 	args = append(args, p.Password)
-	args = append(args, filepath.Join(filepath.Dir(p.DistDir), "/*"))
+	args = append(args, filepath.Join(p.DistDir, "/*"))
 
 	return exec.Command("twine", args...)
 }

--- a/plugin.go
+++ b/plugin.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 )
@@ -40,7 +41,7 @@ func (p Plugin) uploadCommand() *exec.Cmd {
 	args = append(args, p.Username)
 	args = append(args, "--password")
 	args = append(args, p.Password)
-	args = append(args, "dist/*")
+	args = append(args, filepath.Join(filepath.Dir(p.SetupFile), "dist/*"))
 
 	return exec.Command("twine", args...)
 }

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -17,6 +17,7 @@ func TestPublish(t *testing.T) {
 		SetupFile:     "testdata/setup.py",
 		Distributions: strings.Split(os.Getenv("PLUGIN_DISTRIBUTIONS"), " "),
 		SkipBuild:     false,
+		DistDir:       "dist/",
 	}
 	err := plugin.Exec()
 	if err != nil {


### PR DESCRIPTION
Fixes issue where dist directory is assumed to be in the base directory. With this change, you can specify if that directory exists elsewhere.

Edit: Also fixed build dependencies since I was unable to build the project in it's current state without them.