### PR TITLE
Add git to Dockerfile(s) for setuptools-scm to work

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -6,7 +6,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.schema-version="1.0"
 
 RUN apk add -U ca-certificates python3 \
-    python3-dev gcc libc-dev libffi-dev openssl-dev && \
+    python3-dev gcc libc-dev libffi-dev openssl-dev git && \
     rm -rf /var/cache/apk/* && \
     pip3 install --no-cache-dir --upgrade pip setuptools wheel six twine
 

--- a/docker/Dockerfile.linux.arm
+++ b/docker/Dockerfile.linux.arm
@@ -6,7 +6,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.schema-version="1.0"
 
 RUN apk add -U ca-certificates python3 \
-    python3-dev gcc libc-dev libffi-dev openssl-dev && \
+    python3-dev gcc libc-dev libffi-dev openssl-dev git && \
     rm -rf /var/cache/apk/* && \
     pip3 install --no-cache-dir --upgrade pip setuptools wheel six twine
 

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -6,7 +6,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.schema-version="1.0"
 
 RUN apk add -U ca-certificates python3 \
-    python3-dev gcc libc-dev libffi-dev openssl-dev && \
+    python3-dev gcc libc-dev libffi-dev openssl-dev git && \
     rm -rf /var/cache/apk/* && \
     pip3 install --no-cache-dir --upgrade pip setuptools wheel six twine
 


### PR DESCRIPTION
This enables the [`setuptools_scm`](https://pypi.org/project/setuptools-scm/) python module (see no.7 in ["Single-sourcing the package version"](https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version)) to fetch the version to release from git tags & the workdir state. It can be tested by querying the package version:

```bash
$ docker run --rm \
  -v $(pwd):$(pwd) \
  -w $(pwd) \
  plugins/pypi \
  setup.py --version'

0.1.dev24
```

Otherwise it will fail as in https://github.com/cs3org/python-cs3apis/pull/1#issuecomment-626643426 with:

```bash
/drone/src/.eggs/setuptools_scm-3.5.0-py3.8.egg/setuptools_scm/utils.py:145: UserWarning: 'git' was not found
[...]
LookupError: setuptools-scm was unable to detect version for '/drone/src'.
```

cc/ @tboerger. 
